### PR TITLE
feat: continuous retry with exponential backoff (30s→10min) for stalled tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,20 @@
 
 LLM sessions fail in predictable ways. This plugin monitors all sessions and automatically recovers without user intervention.
 
-**Stall recovery** — the stream goes silent but the session stays "busy". The UI shows a blinking cursor with no progress. If no events arrive for 48 seconds, the plugin sends `"continue"` with exponential backoff. After 3 failed attempts it gives up.
+**Stall recovery** — the stream goes silent but the session stays "busy". The UI shows a blinking cursor with no progress. If no events arrive for 48 seconds, the plugin sends `"continue"` with exponential backoff starting at 30s, doubling each retry, capped at 10 minutes. Retries continue indefinitely — the plugin never gives up on a stalled session. Actively-running tool calls that produce output are never interrupted (any event resets the timer).
 
 The plugin extracts the **agent, model, and provider** from the last session message, so it resumes with the exact same configuration the user was using (build, sisyphus, prometheus, etc.).
 _( [#55](https://github.com/anomalyco/opencode/issues/55), [#199](https://github.com/anomalyco/opencode/issues/199), [#283](https://github.com/anomalyco/opencode/issues/283) )_
 
-**Tool calls as raw text** — the model prints tool invocations as raw XML (`<function=edit>...`) instead of executing them. The session goes idle normally but the tool was never run. On idle, the plugin fetches the last messages and scans for XML tool-call patterns (including truncated and alternative formats). If found, it sends a specific recovery prompt.
+**Tool call stall recovery** — when a tool call ends (completed or errored) but the agent doesn't continue, the session stays "busy" indefinitely. The plugin detects this as a stall (no events after the tool ends) and sends `"continue"` with the same exponential backoff. This also works for subagents: when multiple sessions are busy and one has been idle for an extended period (4x the normal timeout), the plugin attempts recovery.
+
+**Tool calls as raw text** — the model prints tool invocations as raw XML (`<function=edit>...`) instead of executing them. The session goes idle normally but the tool was never run. On idle, the plugin fetches the last messages and scans for XML tool-call patterns (including truncated and alternative formats). If found, it sends a specific recovery prompt (up to 3 attempts).
 _( [#150](https://github.com/anomalyco/opencode/issues/150), [#313](https://github.com/anomalyco/opencode/issues/313), [#353](https://github.com/anomalyco/opencode/issues/353) )_
 
 **Hallucination loop** — the model generates the same broken output repeatedly. Each continue just picks up the broken generation. If a session needs 3+ continues within 10 minutes, the plugin aborts the request and sends `"continue"` fresh, forcing a clean restart.
 _( [#283](https://github.com/anomalyco/opencode/issues/283), [#353](https://github.com/anomalyco/opencode/issues/353) )_
 
-**Orphan parent** — a subagent finishes but the parent session stays stuck as "busy" forever. The plugin detects when busyCount drops from >1 to 1, waits 15 seconds, then aborts and resumes the parent.
+**Orphan parent** — a subagent finishes but the parent session stays stuck as "busy" forever. The plugin detects when busyCount drops from >1 to 1, waits 15 seconds, then aborts and resumes the parent. Retries indefinitely with exponential backoff.
 _( [#122](https://github.com/anomalyco/opencode/issues/122), [#199](https://github.com/anomalyco/opencode/issues/199), [#246](https://github.com/anomalyco/opencode/issues/246) )_
 
 **False positives during subagent work** — long tool execution or active subagents can look like a stall. Only the session emitting events gets its timer reset (not all sessions). When multiple sessions are busy, stall detection is paused entirely.
@@ -43,20 +45,26 @@ Any SSE Event
   ├─ has sessionID? → touchSession(sid) — reset only that session's timer
   └─ no sessionID → ignore
 
+message.part.updated events:
+  ├─ tool call "running" → track toolRunningSince
+  └─ tool call "completed"/"error" → clear toolRunningSince, track lastToolOutputAt
+
 session.status events:
   ├─ busy → reset timer, clear retry counters
   └─ idle → schedule tool-text check (1.5s delay)
               └─ fetch messages → scan for XML patterns
-                  ├─ found → send recovery prompt (with backoff)
+                  ├─ found → send recovery prompt (max 3 attempts)
                   └─ not found → do nothing
               └─ orphan check: busyCount dropped from >1 to 1?
-                  └─ 15s watch → abort + continue
+                  └─ 15s watch → abort + continue (continuous retry)
 
 Timer loop (every 5s):
   for each busy session:
-    ├─ orphan watch active? → wait or abort+continue
-    ├─ busyCount > 1? → skip (subagent running)
+    ├─ orphan watch active? → wait or abort+continue (continuous retry w/ backoff)
+    ├─ busyCount > 1?
+    │   └─ idle > 4x timeout? → check subagents, recover or resume (continuous retry)
     └─ idle > 48s? → hallucination loop? abort : continue with backoff
+        └─ continuous retry: 30s → 60s → 120s → 240s → 480s → 600s (cap)
 
 Periodic (every 60s): session.list() to discover missed sessions
 Periodic: cleanup idle sessions older than 10min or >50 entries
@@ -93,6 +101,8 @@ With options:
 }
 ```
 
+> **Note:** `maxRetries` only applies to tool-call-as-text recovery (max 3 attempts). Stream stall recovery retries continuously with exponential backoff and never gives up.
+
 ### Via GitHub (manual clone)
 
 OpenCode may clone the repository to `~/.config/opencode/plugins/opencode-auto-resume/` automatically.
@@ -122,9 +132,9 @@ bun run build
 | `chunkTimeoutMs` | `45000` | Inactivity timeout before considering stream stalled |
 | `gracePeriodMs` | `3000` | Extra wait before acting (lets ESC/status events arrive) |
 | `checkIntervalMs` | `5000` | Timer poll interval |
-| `maxRetries` | `3` | Max auto-resume attempts before giving up |
-| `baseBackoffMs` | `1000` | First retry delay (doubles each attempt) |
-| `maxBackoffMs` | `8000` | Backoff cap |
+| `maxRetries` | `3` | Max tool-call-as-text recovery attempts (stall recovery is unlimited) |
+| `baseBackoffMs` | `30000` | First retry delay — 30s, doubles each attempt |
+| `maxBackoffMs` | `600000` | Backoff cap — 10 minutes |
 | `subagentWaitMs` | `15000` | Wait before treating orphan parent as stuck |
 | `loopMaxContinues` | `3` | Continues in window before triggering abort |
 | `loopWindowMs` | `600000` | Hallucination loop detection window (10 min) |
@@ -149,3 +159,4 @@ The plugin handles all recovery automatically — no manual intervention needed.
 | Orphan parent not detected | Increase `subagentWaitMs` to `20000` |
 | Hallucination loop not caught | Decrease `loopMaxContinues` to `2` |
 | Tool-text not detected | Check server logs — requires SDK message fetching |
+| Agent stalls after tool call ends | Expected to auto-recover with continuous retry (30s initial backoff) |

--- a/src/index.it.test.ts
+++ b/src/index.it.test.ts
@@ -91,20 +91,20 @@ describe("Plugin Core Logic", () => {
 
         test("detects when backoff is required", () => {
             function backoffMs(attempt: number): number {
-                return Math.min(5000 * Math.pow(2, attempt), 160000)
+                return Math.min(30000 * Math.pow(2, attempt - 1), 600000)
             }
 
-            expect(backoffMs(0)).toBe(5000)
-            expect(backoffMs(1)).toBe(10000)
+            expect(backoffMs(1)).toBe(30000)
+            expect(backoffMs(2)).toBe(60000)
             
             const now = Date.now()
-            const lastRetryAt = now - 3000
+            const lastRetryAt = now - 10000
             const elapsed = now - lastRetryAt
-            expect(elapsed < backoffMs(0)).toBe(true)
+            expect(elapsed < backoffMs(1)).toBe(true)
             
-            const lastRetryAt2 = now - 10000
+            const lastRetryAt2 = now - 40000
             const elapsed2 = now - lastRetryAt2
-            expect(elapsed2 >= backoffMs(0)).toBe(true)
+            expect(elapsed2 >= backoffMs(1)).toBe(true)
         })
     })
 

--- a/src/index.plugin.test.ts
+++ b/src/index.plugin.test.ts
@@ -105,27 +105,27 @@ describe("Resume Logic", () => {
 
     test("calculates exponential backoff", () => {
         function backoffMs(attempt: number): number {
-            return Math.min(5000 * Math.pow(2, attempt), 160000)
+            return Math.min(30000 * Math.pow(2, attempt - 1), 600000)
         }
         
-        expect(backoffMs(0)).toBe(5000)
-        expect(backoffMs(1)).toBe(10000)
-        expect(backoffMs(2)).toBe(20000)
-        expect(backoffMs(3)).toBe(40000)
-        expect(backoffMs(4)).toBe(80000)
-        expect(backoffMs(5)).toBe(160000)
-        expect(backoffMs(10)).toBe(160000)
+        expect(backoffMs(1)).toBe(30000)
+        expect(backoffMs(2)).toBe(60000)
+        expect(backoffMs(3)).toBe(120000)
+        expect(backoffMs(4)).toBe(240000)
+        expect(backoffMs(5)).toBe(480000)
+        expect(backoffMs(6)).toBe(600000)
+        expect(backoffMs(10)).toBe(600000)
     })
 
     test("blocks retry during backoff period", () => {
         const now = Date.now()
-        const lastRetryAt = now - 3000
-        const backoff = 5000
+        const lastRetryAt = now - 10000
+        const backoff = 30000
         
         const canRetry = (now - lastRetryAt) >= backoff
         expect(canRetry).toBe(false)
         
-        const later = now + 3000
+        const later = now + 25000
         const canRetryLater = (later - lastRetryAt) >= backoff
         expect(canRetryLater).toBe(true)
     })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -5,8 +5,7 @@ function short(id: string): string {
 }
 
 function backoffMs(attempt: number): number {
-    // v8.0: exponential backoff: 5s, 10s, 20s, 40s, 80s, 160s
-    return Math.min(5000 * Math.pow(2, attempt), 160000)
+    return Math.min(30000 * Math.pow(2, attempt - 1), 600000)
 }
 
 function getSid(ev: Record<string, unknown>): string | undefined {
@@ -52,20 +51,22 @@ describe("short()", () => {
 // -----------------------------------------------------------------------
 
 describe("backoffMs()", () => {
-    test("returns 5000ms for attempt 0", () => {
-        expect(backoffMs(0)).toBe(5000)
+    test("returns 30000ms for attempt 1 (first retry)", () => {
+        expect(backoffMs(1)).toBe(30000)
     })
 
-    test("doubles each attempt (0-indexed)", () => {
-        expect(backoffMs(1)).toBe(10000)
-        expect(backoffMs(2)).toBe(20000)
-        expect(backoffMs(3)).toBe(40000)
-        expect(backoffMs(4)).toBe(80000)
+    test("doubles each attempt (1-indexed)", () => {
+        expect(backoffMs(1)).toBe(30000)
+        expect(backoffMs(2)).toBe(60000)
+        expect(backoffMs(3)).toBe(120000)
+        expect(backoffMs(4)).toBe(240000)
+        expect(backoffMs(5)).toBe(480000)
     })
 
-    test("caps at 160000ms (160s)", () => {
-        expect(backoffMs(10)).toBe(160000)
-        expect(backoffMs(100)).toBe(160000)
+    test("caps at 600000ms (10 minutes)", () => {
+        expect(backoffMs(6)).toBe(600000)
+        expect(backoffMs(10)).toBe(600000)
+        expect(backoffMs(100)).toBe(600000)
     })
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,6 @@ interface SessionWatch {
     userCancelled: boolean
     resumeAttempts: number
     lastRetryAt: number
-    gaveUp: boolean
     orphanWatchStartAt: number | null
     aborting: boolean
     toolTextRecovered: boolean
@@ -34,6 +33,8 @@ interface SessionWatch {
     continuing: boolean
     todos: Todo[]
     todoCheckAttempts: number
+    toolRunningSince: number | null
+    lastToolOutputAt: number | null
 }
 
 // ---------------------------------------------------------------------------
@@ -43,9 +44,9 @@ interface SessionWatch {
 const DEFAULT_CHUNK_TIMEOUT_MS = 45_000
 const DEFAULT_CHECK_INTERVAL_MS = 5_000
 const DEFAULT_GRACE_PERIOD_MS = 3_000
-const DEFAULT_MAX_RETRIES = 3
-const DEFAULT_MAX_BACKOFF_MS = 8_000
-const DEFAULT_BASE_BACKOFF_MS = 1_000
+const DEFAULT_MAX_TOOL_TEXT_RETRIES = 3
+const DEFAULT_MAX_BACKOFF_MS = 600_000
+const DEFAULT_BASE_BACKOFF_MS = 30_000
 const DEFAULT_SUBAGENT_WAIT_MS = 15_000
 const ABORT_CONTINUE_DELAY_MS = 2_000
 const DEFAULT_LOOP_MAX_CONTINUES = 3
@@ -159,8 +160,8 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
     (options?.checkIntervalMs as number) ?? DEFAULT_CHECK_INTERVAL_MS
     const gracePeriodMs: number =
     (options?.gracePeriodMs as number) ?? DEFAULT_GRACE_PERIOD_MS
-    const maxRetries: number =
-    (options?.maxRetries as number) ?? DEFAULT_MAX_RETRIES
+    const maxToolTextRetries: number =
+    (options?.maxRetries as number) ?? DEFAULT_MAX_TOOL_TEXT_RETRIES
     const maxBackoffMs: number =
     (options?.maxBackoffMs as number) ?? DEFAULT_MAX_BACKOFF_MS
     const baseBackoffMs: number =
@@ -226,7 +227,6 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
                 userCancelled: false,
                 resumeAttempts: 0,
                 lastRetryAt: 0,
-                gaveUp: false,
                 orphanWatchStartAt: null,
                 aborting: false,
                 toolTextRecovered: false,
@@ -236,6 +236,8 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
                 continuing: false,
                 todos: [],
                 todoCheckAttempts: 0,
+                toolRunningSince: null,
+                lastToolOutputAt: null,
             }
             sessions.set(sid, w)
         }
@@ -514,7 +516,6 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
     function resetSessionFlags(w: SessionWatch) {
         w.userCancelled = false
         w.resumeAttempts = 0
-        w.gaveUp = false
         w.orphanWatchStartAt = null
         w.aborting = false
         w.toolTextRecovered = false
@@ -522,6 +523,8 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
         w.continueTimestamps = []
         w.idleSince = null
         w.continuing = false
+        w.toolRunningSince = null
+        w.lastToolOutputAt = null
     }
 
     function resetIdleFlags(w: SessionWatch) {
@@ -548,7 +551,7 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
         }
 
         // v8.0: Cap tool-text attempts like regular retries
-        if (w.toolTextAttempts >= maxRetries) return
+        if (w.toolTextAttempts >= maxToolTextRetries) return
 
         await log("debug", `${short(sid)} - checking for tool-call-as-text (attempt ${w.toolTextAttempts + 1})`)
 
@@ -648,7 +651,7 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
             await log(
                 "info",
                 `${bestCandidate.source} detected on ${short(sid)}! ` +
-                `Attempt ${w.toolTextAttempts}/${maxRetries}. Sending recovery prompt...`,
+                `Attempt ${w.toolTextAttempts}/${maxToolTextRetries}. Sending recovery prompt...`,
             )
 
             if (isHallucinationLoop(sid)) {
@@ -700,11 +703,13 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
             await log("info", `${short(sid)} - abort+continue done`)
             w.orphanWatchStartAt = null
             w.resumeAttempts++
+            w.lastRetryAt = Date.now()
             w.aborting = false
             return true
         } catch (err) {
             const errMsg = err instanceof Error ? err.message : String(err)
             await log("warn", `${short(sid)} - continue after abort failed: ${errMsg}`)
+            w.lastRetryAt = Date.now()
             w.aborting = false
             return false
         }
@@ -731,7 +736,11 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
 
         w.resumeAttempts++
         const idleSec = Math.round((now - w.lastActivityAt) / 1000)
-        await log("info", `${reason} on ${short(sid)} (${idleSec}s, retry ${w.resumeAttempts}/${maxRetries})`)
+        const backoffSec = Math.round(requiredBackoff / 1000)
+        const toolInfo = w.toolRunningSince
+            ? ` (tool running for ${Math.round((now - w.toolRunningSince) / 1000)}s)`
+            : ""
+        await log("info", `${reason} on ${short(sid)} (${idleSec}s idle, retry #${w.resumeAttempts}, next backoff ${backoffSec}s)${toolInfo}`)
 
         try {
             await sendContinuePrompt(sid, "continue", w)
@@ -790,33 +799,55 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
                 if (w.orphanWatchStartAt !== null) {
                     const orphanIdle = now - w.orphanWatchStartAt
                     if (orphanIdle >= subagentWaitMs + gracePeriodMs) {
-                        if (w.resumeAttempts < maxRetries) {
-                            const subStatus = await checkSubagentStatus(sid)
-                            if (subStatus.status === "crashed" && subStatus.stuckSid) {
-                                const recovered = await recoverSubagent(subStatus.stuckSid)
-                                if (recovered) {
-                                    await log("info", `Sent recovery prompt to stuck subagent ${short(subStatus.stuckSid)}, waiting...`)
-                                } else {
-                                    await log("info", `Subagent crashed, triggering abort+resume on ${short(sid)}`)
-                                    tryAbortAndResume(sid, w)
-                                }
-                            } else if (subStatus.status === "idle") {
-                                await log("info", `All subagents idle, parent ${short(sid)} stuck. Triggering abort+resume.`)
-                                tryAbortAndResume(sid, w)
+                        const elapsedSinceRetry = now - w.lastRetryAt
+                        const requiredBackoff = backoffMs(w.resumeAttempts)
+                        if (w.lastRetryAt > 0 && elapsedSinceRetry < requiredBackoff) {
+                            continue
+                        }
+                        const subStatus = await checkSubagentStatus(sid)
+                        if (subStatus.status === "crashed" && subStatus.stuckSid) {
+                            const recovered = await recoverSubagent(subStatus.stuckSid)
+                            if (recovered) {
+                                await log("info", `Sent recovery prompt to stuck subagent ${short(subStatus.stuckSid)}, waiting...`)
                             } else {
-                                await log("debug", `Subagent still running, waiting...`)
+                                await log("info", `Subagent crashed, triggering abort+resume on ${short(sid)}`)
+                                tryAbortAndResume(sid, w)
                             }
-                        } else if (!w.gaveUp) {
-                            w.gaveUp = true
-                            w.orphanWatchStartAt = null
-                            w.aborting = false
-                            log("warn", `${short(sid)} - orphan retries exhausted.`)
+                        } else if (subStatus.status === "idle") {
+                            await log("info", `All subagents idle, parent ${short(sid)} stuck. Triggering abort+resume.`)
+                            tryAbortAndResume(sid, w)
+                        } else {
+                            await log("debug", `Subagent still running, waiting...`)
                         }
                     }
                     continue
                 }
 
-                if (numBusy > 1) continue
+                if (numBusy > 1) {
+                    const idle = now - w.lastActivityAt
+                    const multiBusyTimeout = chunkTimeoutMs * 4 + gracePeriodMs
+                    if (idle >= multiBusyTimeout) {
+                        const elapsedSinceRetry = now - w.lastRetryAt
+                        const requiredBackoff = backoffMs(w.resumeAttempts)
+                        if (!(w.lastRetryAt > 0 && elapsedSinceRetry < requiredBackoff)) {
+                            await log("info", `Multi-session stall on ${short(sid)} (${Math.round(idle / 1000)}s idle, ${numBusy} busy). Checking subagent status.`)
+                            const subStatus = await checkSubagentStatus(sid)
+                            if (subStatus.status === "crashed" && subStatus.stuckSid) {
+                                const recovered = await recoverSubagent(subStatus.stuckSid)
+                                if (recovered) {
+                                    await log("info", `Recovered stuck subagent ${short(subStatus.stuckSid)} during multi-busy stall.`)
+                                    w.lastRetryAt = now
+                                }
+                            } else if (subStatus.status === "idle") {
+                                await log("info", `No active subagents for ${short(sid)} during multi-busy stall. Triggering abort+resume.`)
+                                tryAbortAndResume(sid, w)
+                            } else {
+                                tryResume(sid, w, "Multi-session stall")
+                            }
+                        }
+                    }
+                    continue
+                }
 
                 if (w.lastActivityAt > 0 && (now - w.lastActivityAt) > subagentWaitMs) {
                     const subStatus = await checkSubagentStatus(sid)
@@ -838,16 +869,10 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
 
                 const idle = now - w.lastActivityAt
                 if (idle >= chunkTimeoutMs + gracePeriodMs) {
-                    if (w.resumeAttempts < maxRetries) {
-                        tryResume(sid, w, "Stream stall")
-                    } else if (!w.gaveUp) {
-                        w.gaveUp = true
-                        log("warn", `${short(sid)} - all ${maxRetries} retries exhausted.`)
-                    }
+                    tryResume(sid, w, "Stream stall")
                 }
             }
 
-            // v8.0: Periodic cleanup
             cleanupIdleSessions()
         }, checkIntervalMs)
 
@@ -906,7 +931,7 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
                     log("debug", `${short(sid)} -> idle (${currentBusy})`)
 
                     // v8.0: TOOL-CALL-AS-TEXT CHECK — runs regardless of busyCount
-                    if (!w.toolTextRecovered && w.toolTextAttempts < maxRetries) {
+                    if (!w.toolTextRecovered && w.toolTextAttempts < maxToolTextRetries) {
                         setTimeout(() => {
                             checkForToolCallAsText(sid, w)
                         }, TOOL_TEXT_CHECK_DELAY_MS)
@@ -938,10 +963,38 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
                     resetIdleFlags(w)
 
                     // v8.0: Also check for tool-call-as-text on legacy idle event
-                    if (!w.toolTextRecovered && w.toolTextAttempts < maxRetries) {
+                    if (!w.toolTextRecovered && w.toolTextAttempts < maxToolTextRetries) {
                         setTimeout(() => {
                             checkForToolCallAsText(sid, w)
                         }, TOOL_TEXT_CHECK_DELAY_MS)
+                    }
+                }
+                break
+            }
+
+            case "message.part.updated": {
+                if (!sid) break
+                const w = sessions.get(sid)
+                if (!w) break
+                const props = ev.properties as Record<string, unknown> | undefined
+                const part = (props?.part ?? ev.part) as Record<string, unknown> | undefined
+                if (!part) break
+
+                const partType = part.type as string | undefined
+
+                if (partType === "tool" || partType === "tool-invocation") {
+                    const state = (part.state ?? part.toolInvocation) as Record<string, unknown> | undefined
+                    const status = (state?.status ?? state?.state) as string | undefined
+
+                    if (status === "running" || status === "call") {
+                        if (!w.toolRunningSince) {
+                            w.toolRunningSince = Date.now()
+                            log("debug", `${short(sid)} - tool call started running`)
+                        }
+                    } else if (status === "completed" || status === "error" || status === "result") {
+                        w.toolRunningSince = null
+                        w.lastToolOutputAt = Date.now()
+                        log("debug", `${short(sid)} - tool call ended (${status})`)
                     }
                 }
                 break
@@ -1006,7 +1059,7 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
         event: async ({ event }) => {
             if (!initialised) {
                 initialised = true
-                log("info", `opencode-auto-resume ready. timeout=${chunkTimeoutMs}ms, orphan=${subagentWaitMs}ms, loop=${loopMaxContinues}x/${loopWindowMs / 1000}s`)
+                log("info", `opencode-auto-resume ready. timeout=${chunkTimeoutMs / 1000}s, backoff=${baseBackoffMs / 1000}s-${maxBackoffMs / 1000}s, continuous retry, orphan=${subagentWaitMs / 1000}s, loop=${loopMaxContinues}x/${loopWindowMs / 1000}s`)
             }
             handleEvent(event as Record<string, unknown>)
         },
@@ -1016,7 +1069,7 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
             if (ctx.ui && typeof ctx.ui.toast === "function") {
                 ctx.ui.toast({
                     title: "Auto-Resume Plugin",
-                    message: `Loaded with ${chunkTimeoutMs}ms timeout, ${loopMaxContinues} loop attempts`,
+                    message: `Loaded: ${chunkTimeoutMs / 1000}s timeout, continuous retry (${baseBackoffMs / 1000}s-${maxBackoffMs / 1000}s backoff)`,
                     variant: "success",
                     duration: 5000
                 })


### PR DESCRIPTION
I've noticed that Z-ai Coding Plan often stalls after tool call outputs, but by default neither this plugin (as it was before) nor opencode alone handle it properly. The end result is the user ends up having to manually call continue.

This PR fixes that, and removes "giving up" and replaces it with exponential back off (up to 10 minutes).

I've lightly tested this in a scenario that consistently produced stalls and it helped those continue onward.
 
- Remove gaveUp flag and maxRetries cap from stall recovery — retries continue indefinitely
- Change backoff from 1s→8s to 30s→600s (10min cap), doubling each attempt
- Add multi-busy stall detection: recover sessions stuck even when numBusy>1 (4x timeout)
- Add message.part.updated handler to track tool call lifecycle for diagnostics
- Keep maxRetries (3) only for tool-call-as-text recovery (different failure mode)
- Update tryAbortAndResume to track lastRetryAt for proper backoff on abort attempts
- Update tests and README to reflect new behavior