### PR TITLE
fix: handle string session status events

### DIFF
--- a/src/index.integration.test.ts
+++ b/src/index.integration.test.ts
@@ -159,6 +159,58 @@ describe("Plugin Integration", () => {
         await hooks.event({ event: { type: "message", sessionID: "session-1", properties: { delta: { text: "working" } } } })
         await hooks.event({ event: { type: "session.status", sessionID: "session-1", properties: { status: "idle" } } })
     })
+
+    test("string idle status schedules tool-text recovery", async () => {
+        const sid = "ses_tool_text"
+        const promptCalls: Array<{ sid: string; body: string }> = []
+        const ctx = {
+            client: {
+                app: {
+                    log: mock(async () => {})
+                },
+                session: {
+                    list: mock(async () => ({ data: [{ id: sid, status: "idle" }] })),
+                    messages: mock(async (input: { path?: { id: string }; id?: string }) => {
+                        const id = input.path?.id ?? input.id
+                        if (id !== sid) return []
+                        return [
+                            {
+                                role: "user",
+                                agent: "sisyphus",
+                                model: { providerID: "anthropic", modelID: "claude-3" },
+                            },
+                            {
+                                role: "assistant",
+                                parts: [
+                                    {
+                                        type: "text",
+                                        text: "<function=edit><parameter name=\"file\">src/index.ts</parameter>",
+                                    },
+                                ],
+                            },
+                        ]
+                    }),
+                    prompt: mock(async (config: { path: { id: string }; body: { parts: Array<{ text: string }> } }) => {
+                        promptCalls.push({
+                            sid: config.path.id,
+                            body: config.body.parts.map((part) => part.text).join(""),
+                        })
+                        return {}
+                    }),
+                    abort: mock(async () => ({})),
+                },
+            },
+        } as any
+        const hooks = await AutoResumePlugin(ctx, { enabled: true, maxRetries: 1 })
+
+        await hooks.event({ event: { type: "session.status", sessionID: sid, properties: { status: "idle" } } })
+        await new Promise((resolve) => setTimeout(resolve, 3200))
+
+        expect(ctx.client.session.messages).toHaveBeenCalled()
+        expect(promptCalls).toHaveLength(1)
+        expect(promptCalls[0].sid).toBe(sid)
+        expect(promptCalls[0].body).toContain("raw tool call")
+    })
 })
 
 describe("Agent Extraction Flow", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -281,12 +281,15 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
         )
     }
 
-    function getStatus(ev: Record<string, unknown>): Record<string, unknown> | undefined {
+    function getStatusType(ev: Record<string, unknown>): string {
         const props = ev.properties as Record<string, unknown> | undefined
-        return (
-            (ev.status as Record<string, unknown> | undefined) ??
-            (props?.status as Record<string, unknown> | undefined)
-        )
+        const rawStatus = ev.status ?? props?.status
+        if (typeof rawStatus === "string") return rawStatus
+        if (rawStatus && typeof rawStatus === "object") {
+            const type = (rawStatus as Record<string, unknown>).type
+            if (typeof type === "string") return type
+        }
+        return "unknown"
     }
 
     function short(sid: string): string {
@@ -1174,8 +1177,7 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
         switch (type) {
             case "session.status": {
                 if (!sid) break
-                const status = getStatus(ev)
-                const statusType = (status?.type as string) ?? "unknown"
+                const statusType = getStatusType(ev)
                 const w = ensureWatch(sid)
                 w.status = statusType as SessionWatch["status"]
 


### PR DESCRIPTION
## What changed

- Accept `session.status` payloads where `status` is a plain string as well as object payloads with `status.type`.
- Add an integration regression test proving a string `idle` status schedules raw tool-call text recovery.

## Why

The plugin currently reads status events as if the payload is always shaped like `{ type: "idle" }`. Several tests and event mocks use the common string form instead:

```ts
{ type: "session.status", sessionID, properties: { status: "idle" } }
```

With that shape, the plugin resolves the status as `unknown`, so the idle branch never schedules the delayed tool-text recovery check. That means an assistant response containing a raw tool call as text can be left unrecovered even though the session reported `idle`.

The new helper preserves the existing object-shaped handling while also accepting string status values.

## Validation

- `bun test src/index.integration.test.ts -t "string idle status schedules tool-text recovery"`
- `bun test`
- `bun run build`

Note: I also checked `npx tsc --noEmit`, but this repository currently has pre-existing test type errors unrelated to this change, so I did not use that as a passing validation gate.
