### PR TITLE
feat: use tool call hooks to track running tool calls

### DIFF
--- a/src/index.inflight.test.ts
+++ b/src/index.inflight.test.ts
@@ -1,0 +1,207 @@
+import { describe, test, expect, mock } from "bun:test"
+import { AutoResumePlugin } from "./index"
+
+type PromptCall = { sid: string; body: string; agent?: string }
+
+function createMockContext(opts: { messages?: Record<string, Array<any>> } = {}) {
+    const promptCalls: PromptCall[] = []
+    const abortCalls: Array<{ sid: string }> = []
+    const ctx = {
+        client: {
+            app: { log: mock(async (_o: any) => {}) },
+            session: {
+                list: mock(async () => ({ data: [] })),
+                status: mock(async () => ({ data: {} })),
+                messages: mock(async (config: { path: { id: string } }) => {
+                    return opts.messages?.[config.path.id] ?? []
+                }),
+                prompt: mock(async (config: any) => {
+                    promptCalls.push({
+                        sid: config.path.id,
+                        body: config.body.parts.map((p: any) => p.text).join(""),
+                        agent: config.agent,
+                    })
+                    return {}
+                }),
+                abort: mock(async (config: { path: { id: string } }) => {
+                    abortCalls.push({ sid: config.path.id })
+                    return {}
+                }),
+            },
+        },
+        ui: { toast: mock(async () => {}) },
+    } as any
+    return { ctx, promptCalls, abortCalls }
+}
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+const FAST = {
+    checkIntervalMs: 20,
+    chunkTimeoutMs: 50,
+    gracePeriodMs: 0,
+    subagentWaitMs: 100_000,
+    maxRetries: 1,
+    baseBackoffMs: 1,
+    maxBackoffMs: 1,
+    loopMaxContinues: 99,
+}
+
+async function setup(extra: Record<string, unknown> = {}) {
+    const { ctx, promptCalls, abortCalls } = createMockContext()
+    const hooks = await AutoResumePlugin(ctx, { ...FAST, ...extra } as any)
+    return { hooks, promptCalls, abortCalls }
+}
+
+async function busy(hooks: any, sid: string) {
+    await hooks.event({ event: { type: "session.status", sessionID: sid, properties: { status: "busy" } } })
+}
+
+async function toolBefore(hooks: any, sid: string, callID = "c1", tool = "bash") {
+    await hooks["tool.execute.before"]({ tool, sessionID: sid, callID }, { args: {} })
+}
+
+async function toolAfter(hooks: any, sid: string, callID = "c1", tool = "bash") {
+    await hooks["tool.execute.after"]({ tool, sessionID: sid, callID, args: {} }, { title: "", output: "", metadata: {} })
+}
+
+async function cmdBefore(hooks: any, sid: string) {
+    await hooks["command.execute.before"]({ command: "sleep", sessionID: sid, arguments: "10" }, { parts: [] })
+}
+
+async function cmdExecuted(hooks: any, sid: string) {
+    await hooks.event({ event: { type: "command.executed", sessionID: sid, properties: { sessionID: sid } } })
+}
+
+describe("deterministic in-flight tool tracking", () => {
+    test("long-running tool call is not aborted past the stall threshold", async () => {
+        const { hooks, abortCalls, promptCalls } = await setup()
+        const sid = "ses_long_tool"
+        await busy(hooks, sid)
+        await toolBefore(hooks, sid)
+        await wait(250)
+        expect(abortCalls.filter((a) => a.sid === sid)).toHaveLength(0)
+        expect(promptCalls.filter((p) => p.sid === sid)).toHaveLength(0)
+    })
+
+    test("stall recovery fires after the tool finishes", async () => {
+        const { hooks, promptCalls, abortCalls } = await setup()
+        const sid = "ses_long_tool_release"
+        await busy(hooks, sid)
+        await toolBefore(hooks, sid)
+        await wait(150)
+        await toolAfter(hooks, sid)
+        await wait(250)
+        // chunk-timeout path sends a continue prompt (no abort) once the guard releases
+        expect(promptCalls.filter((p) => p.sid === sid).length).toBeGreaterThanOrEqual(1)
+        expect(abortCalls.filter((a) => a.sid === sid)).toHaveLength(0)
+    })
+
+    test("subagent delegation (task tool in-flight) protects the parent", async () => {
+        const { hooks, abortCalls, promptCalls } = await setup()
+        const parent = "ses_parent_delegation"
+        await busy(hooks, parent)
+        await toolBefore(hooks, parent, "t1", "task")
+        await wait(250)
+        expect(abortCalls.filter((a) => a.sid === parent)).toHaveLength(0)
+        expect(promptCalls.filter((p) => p.sid === parent)).toHaveLength(0)
+        await toolAfter(hooks, parent, "t1", "task")
+        await wait(250)
+        expect(promptCalls.filter((p) => p.sid === parent).length).toBeGreaterThanOrEqual(1)
+    })
+
+    test("command in-flight is not aborted; command.executed releases it", async () => {
+        const { hooks, abortCalls, promptCalls } = await setup()
+        const sid = "ses_long_cmd"
+        await busy(hooks, sid)
+        await cmdBefore(hooks, sid)
+        await wait(250)
+        expect(abortCalls.filter((a) => a.sid === sid)).toHaveLength(0)
+        expect(promptCalls.filter((p) => p.sid === sid)).toHaveLength(0)
+        await cmdExecuted(hooks, sid)
+        await wait(250)
+        expect(promptCalls.filter((p) => p.sid === sid).length).toBeGreaterThanOrEqual(1)
+    })
+
+    test("command.executed for one session does not wipe another session's in-flight guard", async () => {
+        const { hooks, abortCalls } = await setup()
+        const a = "ses_a"
+        const b = "ses_b"
+        await busy(hooks, a)
+        await toolBefore(hooks, a, "ca")
+        await busy(hooks, b)
+        await wait(150)
+        await cmdExecuted(hooks, b)
+        await wait(250)
+        // A's tool is still in-flight → A must NOT have been aborted
+        expect(abortCalls.filter((x) => x.sid === a)).toHaveLength(0)
+    })
+
+    test("counters reset on idle → stall recovery fires on next busy cycle", async () => {
+        const { hooks, promptCalls } = await setup()
+        const sid = "ses_idle_reset"
+        await busy(hooks, sid)
+        await toolBefore(hooks, sid)
+        await wait(120)
+        await hooks.event({ event: { type: "session.status", sessionID: sid, properties: { status: "idle" } } })
+        await busy(hooks, sid)
+        await wait(250)
+        expect(promptCalls.filter((p) => p.sid === sid).length).toBeGreaterThanOrEqual(1)
+    })
+
+    test("counters reset on session.error (non-abort) → recovery fires on next busy cycle", async () => {
+        const { hooks, promptCalls } = await setup()
+        const sid = "ses_err_reset"
+        await busy(hooks, sid)
+        await toolBefore(hooks, sid)
+        await wait(120)
+        await hooks.event({
+            event: { type: "session.error", sessionID: sid, properties: { error: { name: "TimeoutError" } } },
+        })
+        await busy(hooks, sid)
+        await wait(250)
+        expect(promptCalls.filter((p) => p.sid === sid).length).toBeGreaterThanOrEqual(1)
+    })
+
+    test("counters reset on session.created (reused id) → recovery fires on next busy cycle", async () => {
+        const { hooks, promptCalls } = await setup()
+        const sid = "ses_created_reset"
+        await busy(hooks, sid)
+        await toolBefore(hooks, sid)
+        await wait(120)
+        await hooks.event({ event: { type: "session.created", sessionID: sid } })
+        await busy(hooks, sid)
+        await wait(250)
+        expect(promptCalls.filter((p) => p.sid === sid).length).toBeGreaterThanOrEqual(1)
+    })
+
+    test("callID undefined is safe and the counter still guards", async () => {
+        const { hooks, abortCalls, promptCalls } = await setup()
+        const sid = "ses_noid"
+        await busy(hooks, sid)
+        await hooks["tool.execute.before"]({ tool: "bash", sessionID: sid, callID: "" as any }, { args: {} })
+        await wait(200)
+        expect(abortCalls.filter((a) => a.sid === sid)).toHaveLength(0)
+        await hooks["tool.execute.after"]({ tool: "bash", sessionID: sid, callID: "" as any, args: {} }, { title: "", output: "", metadata: {} })
+        await wait(250)
+        expect(promptCalls.filter((p) => p.sid === sid).length).toBeGreaterThanOrEqual(1)
+    })
+
+    test("concurrent tool calls: abort stays suppressed until the last one finishes", async () => {
+        const { hooks, abortCalls, promptCalls } = await setup()
+        const sid = "ses_concurrent"
+        await busy(hooks, sid)
+        await toolBefore(hooks, sid, "c1")
+        await toolBefore(hooks, sid, "c2")
+        await wait(200)
+        expect(abortCalls.filter((a) => a.sid === sid)).toHaveLength(0)
+        await toolAfter(hooks, sid, "c1")
+        await wait(200)
+        // one tool still running → still suppressed
+        expect(abortCalls.filter((a) => a.sid === sid)).toHaveLength(0)
+        expect(promptCalls.filter((p) => p.sid === sid)).toHaveLength(0)
+        await toolAfter(hooks, sid, "c2")
+        await wait(250)
+        expect(promptCalls.filter((p) => p.sid === sid).length).toBeGreaterThanOrEqual(1)
+    })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,8 @@ interface SessionWatch {
     isSubagent: boolean
     completionSignaled: boolean
     todoNudgeAttempts: number
+    pendingTools: number
+    pendingCommands: number
 }
 
 const DEFAULT_CHUNK_TIMEOUT_MS = 45_000
@@ -239,6 +241,8 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
                 isSubagent: false,
                 completionSignaled: false,
                 todoNudgeAttempts: 0,
+                pendingTools: 0,
+                pendingCommands: 0,
             }
             sessions.set(sid, w)
         }
@@ -250,6 +254,10 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
         if (w && w.status === "busy" && !w.userCancelled) {
             w.lastActivityAt = Date.now()
         }
+    }
+
+    function hasInflightTools(w: SessionWatch): boolean {
+        return w.pendingTools > 0 || w.pendingCommands > 0
     }
 
     function busyCount(): number {
@@ -628,6 +636,8 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
     function resetSessionFlags(w: SessionWatch) {
         w.userCancelled = false
         w.resumeAttempts = 0
+        w.pendingTools = 0
+        w.pendingCommands = 0
         w.gaveUp = false
         w.orphanWatchStartAt = null
         w.aborting = false
@@ -651,6 +661,8 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
         w.aborting = false
         w.orphanWatchStartAt = null
         w.idleSince = Date.now()
+        w.pendingTools = 0
+        w.pendingCommands = 0
     }
 
     /**
@@ -942,7 +954,11 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
             }
 
             if (isHallucinationLoop(sid)) {
-                // Check if session has an active tool before aborting
+                if (hasInflightTools(w)) {
+                    await log("debug", `Session ${short(sid)} has ${w.pendingTools} tool(s) in-flight, skipping hallucination abort`)
+                    return
+                }
+                // Fallback: polled heuristic for sessions discovered without hooks
                 const hasActiveTool = await checkSessionHasActiveTool(sid)
                 if (hasActiveTool) {
                     await log("debug", `Session ${short(sid)} has active tool, skipping hallucination abort`)
@@ -1026,7 +1042,12 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
         if (w.lastRetryAt > 0 && elapsedSinceRetry < requiredBackoff) return false
 
         if (isHallucinationLoop(sid)) {
-            // Check if session has an active tool before aborting
+            if (hasInflightTools(w)) {
+                await log("debug", `Session ${short(sid)} has ${w.pendingTools} tool(s) in-flight, skipping hallucination abort`)
+                w.lastRetryAt = now
+                return false
+            }
+            // Fallback: polled heuristic for sessions discovered without hooks
             const hasActiveTool = await checkSessionHasActiveTool(sid)
             if (hasActiveTool) {
                 await log("debug", `Session ${short(sid)} has active tool, skipping hallucination abort`)
@@ -1107,6 +1128,12 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
                     if (orphanIdle >= subagentWaitMs + gracePeriodMs) {
                         if (w.resumeAttempts < maxRetries) {
                             // Guard: never abort the parent while it is running a tool.
+                            // Primary: deterministic in-flight counters from hooks.
+                            if (hasInflightTools(w)) {
+                                await log("debug", `Parent ${short(sid)} has ${w.pendingTools} tool(s) in-flight, skipping orphan-watch abort`)
+                                w.orphanWatchStartAt = now
+                                continue
+                            }
                             // Paths B (subagentWait) and C (chunkTimeout) already check
                             // checkSessionHasActiveTool before aborting; path A was missing
                             // it, so a long-running parent tool was killed when a subagent
@@ -1160,6 +1187,12 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
                         continue
                     }
 
+                    if (hasInflightTools(w)) {
+                        await log("debug", `Session ${short(sid)} has ${w.pendingTools} tool(s) in-flight, skipping abort check`)
+                        w.lastSubagentCheckAt = now
+                        continue
+                    }
+                    
                     const hasActiveTool = await checkSessionHasActiveTool(sid)
                     if (hasActiveTool) {
                         await log("debug", `Session ${short(sid)} has active tool call, skipping abort check`)
@@ -1186,16 +1219,23 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
 
                 const idle = now - w.lastActivityAt
                 if (idle >= chunkTimeoutMs + gracePeriodMs) {
-                    // Check if main session has an active tool call - if so, don't resume
-                    const hasActiveTool = await checkSessionHasActiveTool(sid)
-                    if (hasActiveTool) {
-                        await log("debug", `Session ${short(sid)} has active tool call, skipping stall recovery`)
+                    // Primary: deterministic in-flight counters from hooks.
+                    // A long-running build/test/command must never be aborted.
+                    if (hasInflightTools(w)) {
+                        await log("debug", `Session ${short(sid)} has ${w.pendingTools} tool(s) in-flight, skipping stall recovery`)
                         w.lastSubagentCheckAt = now
-                    } else if (w.resumeAttempts < maxRetries) {
-                        tryResume(sid, w, "Stream stall")
-                    } else if (!w.gaveUp) {
-                        w.gaveUp = true
-                        log("warn", `${short(sid)} - all ${maxRetries} retries exhausted.`)
+                    } else {
+                        // Fallback: Check if main session has an active tool call - if so, don't resume
+                        const hasActiveTool = await checkSessionHasActiveTool(sid)
+                        if (hasActiveTool) {
+                            await log("debug", `Session ${short(sid)} has active tool call, skipping stall recovery`)
+                            w.lastSubagentCheckAt = now
+                        } else if (w.resumeAttempts < maxRetries) {
+                            tryResume(sid, w, "Stream stall")
+                        } else if (!w.gaveUp) {
+                            w.gaveUp = true
+                            log("warn", `${short(sid)} - all ${maxRetries} retries exhausted.`)
+                        }
                     }
                 }
             }
@@ -1294,7 +1334,9 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
 
             case "session.created": {
                 if (!sid) break
-                ensureWatch(sid)
+                const w = ensureWatch(sid)
+                w.pendingTools = 0
+                w.pendingCommands = 0
                 log("debug", `New session: ${short(sid)} (${sessions.size})`)
                 break
             }
@@ -1400,12 +1442,23 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
                     (errorObj?.data as Record<string, unknown>)?.message as string | undefined ??
                     String(errorObj?.data ?? "")
                 log("debug", `Session error: ${errorName} - ${errorMessage}`)
+
+                if (sid) {
+                    const w = sessions.get(sid)
+                    if (w) { w.pendingTools = 0; w.pendingCommands = 0 }
+                }
                 break
             }
 
             case "command.executed": {
                 for (const [, w] of sessions) {
                     resetSessionFlags(w)
+                }
+                if (!sid) break
+                const w = sessions.get(sid)
+                if (w) {
+                    w.pendingCommands = Math.max(0, w.pendingCommands - 1)
+                    w.lastActivityAt = Date.now()
                 }
                 break
             }
@@ -1453,6 +1506,27 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
         },
         tool: {
             "task_complete": taskCompleteTool,
+        },
+
+        "tool.execute.before": async (input) => {
+            if (!input?.sessionID) return
+            const w = ensureWatch(input.sessionID)
+            w.pendingTools++
+            w.lastActivityAt = Date.now()
+        },
+
+        "command.execute.before": async (input) => {
+            if (!input?.sessionID) return
+            const w = ensureWatch(input.sessionID)
+            w.pendingCommands++
+            w.lastActivityAt = Date.now()
+        },
+
+        "tool.execute.after": async (input) => {
+            if (!input?.sessionID) return
+            const w = ensureWatch(input.sessionID)
+            w.pendingTools = Math.max(0, w.pendingTools - 1)
+            w.lastActivityAt = Date.now()
         },
     }
 }


### PR DESCRIPTION
When using your plugin i detected a lot of interrupts of long running tool calls and commands.
My sub agents were also interrupted.

Started my own plugin before i knew about yours and had this logic in there.
https://github.com/BacLuc/opencode-keep-running

Generated with AI, treat with caution.

I will keep testing this in my local setup.