### PR TITLE
fix: keep re-nudging idle sessions with open todos after failed resume

### DIFF
--- a/src/index.continue.test.ts
+++ b/src/index.continue.test.ts
@@ -432,3 +432,118 @@ describe("Continue behavior — 🎉 race condition fix", () => {
         expect(promptCalls.length).toBe(0)
     })
 })
+
+describe("Continue behavior — periodic idle recheck", () => {
+    test("periodic timer fires second nudge when session stays idle after first nudge", async () => {
+        const { ctx, promptCalls } = createContinueContext({
+            // Use "idle" as initial status so the periodic timer's status sync
+            // (line 1134-1137) doesn't overwrite w.status back to "busy".
+            sessions: [{ id: "ses_periodic", status: "idle" }],
+            messages: {
+                ses_periodic: [
+                    { role: "user", parts: [{ type: "text", text: "do work" }] },
+                    { role: "assistant", parts: [{ type: "text", text: "step 1" }] }
+                ]
+            }
+        })
+        const hooks = await AutoResumePlugin(ctx, {
+            enabled: true,
+            baseBackoffMs: 1,
+            checkIntervalMs: 50,
+            maxRetries: 5,
+            // Raise loopMaxContinues so isHallucinationLoop (which also counts
+            // periodic tryResume calls) doesn't intercept the second nudge.
+            loopMaxContinues: 10
+        })
+
+        await hooks.event(makeTodoUpdatedEvent("ses_periodic", OPEN_TODOS))
+
+        // Fire idle event → triggers idle handler → nudge 1
+        await hooks.event(makeStatusEvent("ses_periodic", "idle"))
+
+        // handleEvent is fire-and-forget (line 1532 lacks await),
+        // so yield briefly for the async chain to complete.
+        await wait(20)
+        expect(promptCalls.length).toBeGreaterThanOrEqual(1)
+
+        // Session stays idle — no more idle events.
+        // The periodic timer (50ms interval) rechecks and sends nudge 2.
+        await wait(400)
+        expect(promptCalls.length).toBeGreaterThanOrEqual(2)
+
+        const secondBody = promptCalls[1].body
+        expect(secondBody).toContain("unfinished task")
+    })
+
+    test("periodic recheck respects busyCount > 0 (skips nudge when subagent busy)", async () => {
+        const { ctx, promptCalls } = createContinueContext({
+            sessions: [
+                // ses_parent starts idle so periodic timer sync doesn't reset it,
+                // but ses_sub stays busy → busyCount = 1 → no nudge
+                { id: "ses_parent", status: "idle" },
+                { id: "ses_sub", status: "busy" }
+            ],
+            messages: {
+                ses_parent: [
+                    { role: "user", parts: [{ type: "text", text: "do work" }] },
+                    { role: "assistant", parts: [{ type: "text", text: "waiting for sub" }] }
+                ],
+                ses_sub: [
+                    { role: "assistant", parts: [{ type: "text", text: "working" }] }
+                ]
+            }
+        })
+        const hooks = await AutoResumePlugin(ctx, {
+            enabled: true,
+            baseBackoffMs: 1,
+            checkIntervalMs: 50,
+            maxRetries: 5,
+            loopMaxContinues: 10
+        })
+
+        // Register both sessions
+        await hooks.event(makeStatusEvent("ses_parent", "busy"))
+        await hooks.event(makeStatusEvent("ses_sub", "busy"))
+        await hooks.event(makeTodoUpdatedEvent("ses_parent", OPEN_TODOS))
+
+        // Parent goes idle but subagent still busy → busyCount = 1
+        await hooks.event(makeStatusEvent("ses_parent", "idle"))
+
+        // The idle handler respects busyCount > 0, so no instant nudge.
+        // The periodic recheck also checks busyCount() !== 0.
+        await wait(500)
+        expect(promptCalls.length).toBe(0)
+    })
+
+    test("periodic recheck respects maxRetries limit and stops after threshold", async () => {
+        const { ctx, promptCalls } = createContinueContext({
+            sessions: [{ id: "ses_limited", status: "idle" }],
+            messages: {
+                ses_limited: [
+                    { role: "user", parts: [{ type: "text", text: "do work" }] },
+                    { role: "assistant", parts: [{ type: "text", text: "step 1" }] }
+                ]
+            }
+        })
+        const hooks = await AutoResumePlugin(ctx, {
+            enabled: true,
+            baseBackoffMs: 1,
+            checkIntervalMs: 50,
+            maxRetries: 2,
+            loopMaxContinues: 10
+        })
+
+        await hooks.event(makeTodoUpdatedEvent("ses_limited", OPEN_TODOS))
+        await hooks.event(makeStatusEvent("ses_limited", "idle"))
+
+        // handleEvent is fire-and-forget; yield briefly for chain.
+        await wait(20)
+        expect(promptCalls.length).toBeGreaterThanOrEqual(1)
+
+        // Wait enough periodic timer cycles for retries to exhaust.
+        // todoNudgeAttempts: 0 → idle handler sets to 1 → periodic sets to 2,
+        // then stops at maxRetries=2 (todoNudgeAttempts >= maxRetries).
+        await wait(600)
+        expect(promptCalls.length).toBe(2)
+    })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,8 +158,16 @@ function containsDoneClaimPattern(text: string): boolean {
     return DONE_CLAIM_PATTERNS.some((pat) => pat.test(lastLines))
 }
 
+function isOpenTodo(t: Todo): boolean {
+    return t.status === "pending" || t.status === "in_progress"
+}
+
+function getOpenTodos(todos: Todo[]): Todo[] {
+    return todos.filter(isOpenTodo)
+}
+
 export function buildOpenTodosReminder(todos: Todo[]): string {
-    const open = todos.filter(t => t.status === "pending" || t.status === "in_progress")
+    const open = getOpenTodos(todos)
     if (open.length === 0) return "continue"
     const list = open.map((t, i) => `${i + 1}. [${t.status}] ${t.content}`).join("\n")
     const plural = open.length > 1 ? "s" : ""
@@ -852,7 +860,7 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
                     if (containsReadyToContinuePattern(text)) {
                         // Check if todos exist and are all completed/cancelled
                         const todos = w.todos || []
-                        const hasOpenTodos = todos.some(t => t.status === "pending" || t.status === "in_progress")
+                        const hasOpenTodos = todos.some(isOpenTodo)
                         
                         if (!hasOpenTodos && todos.length > 0) {
                             // Todos exist but all are completed - check if we've tried enough times
@@ -891,7 +899,7 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
                     // This catches cases where model says "task completed" but doesn't use 🎉 or tool_call
                     if (!bestCandidate && containsDoneClaimPattern(text)) {
                         const todos = w.todos || []
-                        const hasOpenTodos = todos.some(t => t.status === "pending" || t.status === "in_progress")
+                        const hasOpenTodos = todos.some(isOpenTodo)
                         
                     if (hasOpenTodos) {
                         await log("info", `${short(sid)} - model claims done but todos remain open. Sending recovery prompt...`)
@@ -924,11 +932,11 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
 
             if (!bestCandidate) {
                 const todos = w.todos || []
-                const hasOpenTodos = todos.some(t => t.status === "pending" || t.status === "in_progress")
+                const hasOpenTodos = todos.some(isOpenTodo)
                 
                 if (hasOpenTodos && busyCount() === 0) {
                     const reminder = buildOpenTodosReminder(todos)
-                    await log("info", `${short(sid)} - no activity detected but todos remain open (${todos.filter(t => t.status === "pending" || t.status === "in_progress").length} tasks). Sending reminder...`)
+                    await log("info", `${short(sid)} - no activity detected but todos remain open (${getOpenTodos(todos).length} tasks). Sending reminder...`)
                     bestCandidate = {
                         prompt: reminder,
                         source: "idle-with-open-todos-reminder",
@@ -1257,6 +1265,33 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
                 }
             }
 
+            // Periodic idle session recheck: resume idle sessions with open todos
+            for (const [sid, w] of sessions) {
+                if (w.status !== "idle") continue
+                if (w.isSubagent) continue
+                if (w.userCancelled || w.completionSignaled) continue
+                if (w.continuing) continue
+                if (busyCount() !== 0) continue
+                const open = getOpenTodos(w.todos || [])
+                if (open.length === 0) continue
+                if (w.todoNudgeAttempts >= maxRetries) continue
+                const elapsedSinceLastNudge = Date.now() - w.lastRetryAt
+                const requiredBackoff = backoffMs(w.todoNudgeAttempts)
+                if (w.lastRetryAt > 0 && elapsedSinceLastNudge < requiredBackoff) continue
+                const isCelebration = await lastAssistantEndsWithCelebration(sid)
+                if (isCelebration) {
+                    w.toolTextRecovered = true
+                    w.completionSignaled = true
+                    continue
+                }
+                const reminder = buildOpenTodosReminder(w.todos || [])
+                const sent = await tryResume(sid, w, "Idle with open todos (periodic)", reminder)
+                if (sent) {
+                    w.todoNudgeAttempts++
+                    await log("info", `${short(sid)} - idle periodic recheck: nudge ${w.todoNudgeAttempts}/${maxRetries}`)
+                }
+            }
+
             // Periodic cleanup
             cleanupIdleSessions()
         }, checkIntervalMs)
@@ -1326,9 +1361,9 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
 
                     if (!w.isSubagent) {
                         const todos = w.todos || []
-                        const hasOpenTodos = todos.some(t => t.status === "pending" || t.status === "in_progress")
+                        const open = getOpenTodos(todos)
                         
-                        if (hasOpenTodos && currentBusy === 0 && !w.completionSignaled && !w.userCancelled && w.todoNudgeAttempts < maxRetries) {
+                        if (open.length > 0 && currentBusy === 0 && !w.completionSignaled && !w.userCancelled && w.todoNudgeAttempts < maxRetries) {
                             const isCelebration = await lastAssistantEndsWithCelebration(sid)
                             if (isCelebration) {
                                 await log("info", `${short(sid)} - 🎉 detected in idle handler, skipping continue`)
@@ -1338,8 +1373,8 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
                             } else {
                                 w.todoNudgeAttempts++
                                 const reminder = buildOpenTodosReminder(todos)
-                                await log("info", `${short(sid)} - idle with ${todos.filter(t => t.status === "pending" || t.status === "in_progress").length} open todos. Sending reminder (nudge ${w.todoNudgeAttempts}/${maxRetries})...`)
-                                tryResume(sid, w, "Idle with open todos", reminder)
+                                await log("info", `${short(sid)} - idle with ${open.length} open todos. Sending reminder (nudge ${w.todoNudgeAttempts}/${maxRetries})...`)
+                                await tryResume(sid, w, "Idle with open todos", reminder)
                             }
                         }
                     }


### PR DESCRIPTION
## Problem

When the model stops responding mid-session with open todos, the plugin nudges once via the idle event handler. If that nudge fails (model doesn't respond, network hiccup, etc.), nothing re-triggers it — the idle event only fires once per `busy→idle` transition, so the session just sits there forever.

Two structural issues:

1. `tryResume()` was called fire-and-forget in the idle handler — if it threw, nobody noticed.
2. The periodic timer only checked `busy` sessions (`if (w.status !== "busy") continue`), so idle sessions with unfinished work were invisible to it.

## Fix

**`await tryResume` in idle handler** — so failures propagate and the session state stays consistent.

**Periodic idle-session recheck** — a new loop in the periodic timer that catches idle sessions with open todos and re-nudges them with exponential backoff. Same guards as the idle handler (subagent check, busyCount, completionSignaled, userCancelled, maxRetries cap, celebration detection) plus backoff and a `!continuing` guard appropriate for a timer context.

**DRY cleanup** — extracted `isOpenTodo()` / `getOpenTodos()` helpers to replace the repeated inline predicate across idle handler, periodic recheck, and `checkForToolCallAsText`.

## Builds on

This sits on top of 407e85a which fixed the counter accumulation bug (todoNudgeAttempts was being reset on every busy→idle, so maxRetries never actually capped anything). That fix makes the counter work; this fix makes the retry mechanism actually fire more than once.

## Tests

3 new regression tests in `index.continue.test.ts`:
- Periodic timer fires a second nudge when session stays idle after first attempt
- Periodic recheck skips nudge when busyCount > 0 (subagent still running)  
- Periodic recheck stops after maxRetries threshold

Full suite: 203 pass, 1 pre-existing fail (unrelated `index.events.test.ts:683`).