### PR TITLE
fix: re-arm auto-resume when the user sends a new message after ESC

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ _Motivated by:_
 
 User presses ESC to cancel a request. The plugin detects `MessageAbortedError` and marks all busy sessions as cancelled, never resuming them. The grace period (`gracePeriodMs`) also lets late ESC/status events arrive before any action.
 
+The back-off lifts as soon as the user sends a new prompt in that session (`chat.message` hook): a fresh user message starts a new round of work, so auto-resume re-arms. The plugin's own recovery prompts do not re-arm it. The same applies to the `task_complete` latch.
+
 _Motivated by:_
 - [#28453](https://github.com/anomalyco/opencode/issues/28453) — ACP session/cancel emits agent_error for MessageAbortedError before cancelled result
 - [#32432](https://github.com/anomalyco/opencode/issues/32432) — Cancelled subagents can't be opened in TUI + Ctrl+X intermittently fails

--- a/src/index.rearm.test.ts
+++ b/src/index.rearm.test.ts
@@ -1,0 +1,201 @@
+import { describe, test, expect, mock } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { AutoResumePlugin } from "./index"
+
+const SOURCE = readFileSync(join(import.meta.dir, "index.ts"), "utf8")
+
+type LogCall = { level: string; message: string }
+type PromptCall = { sid: string; body: string }
+
+function createMockContext() {
+    const logCalls: LogCall[] = []
+    const promptCalls: PromptCall[] = []
+    const ctx = {
+        client: {
+            app: {
+                log: mock(async (o: { body: { level: string; message: string } }) => {
+                    logCalls.push({ level: o.body.level, message: o.body.message })
+                }),
+            },
+            session: {
+                list: mock(async () => ({ data: [] })),
+                status: mock(async () => ({ data: {} })),
+                messages: mock(async () => []),
+                prompt: mock(async (config: any) => {
+                    promptCalls.push({
+                        sid: config.path.id,
+                        body: config.body.parts.map((p: any) => p.text).join(""),
+                    })
+                    return {}
+                }),
+                abort: mock(async () => ({})),
+            },
+        },
+        ui: { toast: mock(async () => {}) },
+    } as any
+    return { ctx, logCalls, promptCalls }
+}
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+async function waitFor(cond: () => boolean, timeoutMs = 3000): Promise<boolean> {
+    const start = Date.now()
+    while (Date.now() - start < timeoutMs) {
+        if (cond()) return true
+        await wait(10)
+    }
+    return cond()
+}
+
+const FAST = {
+    enabled: true,
+    checkIntervalMs: 20,
+    chunkTimeoutMs: 100_000,
+    gracePeriodMs: 0,
+    subagentWaitMs: 100_000,
+    maxRetries: 3,
+    baseBackoffMs: 200,
+    maxBackoffMs: 400,
+    loopMaxContinues: 99,
+    toolTextCheckDelayMs: 50_000,
+    maxRecoveryRetries: 3,
+    warmupMs: 60_000,
+}
+
+async function setup() {
+    const { ctx, logCalls, promptCalls } = createMockContext()
+    const hooks = await AutoResumePlugin(ctx, FAST as any)
+    return { hooks, logCalls, promptCalls }
+}
+
+async function busy(hooks: any, sid: string) {
+    await hooks.event({ event: { type: "session.status", sessionID: sid, properties: { status: "busy" } } })
+}
+
+async function idle(hooks: any, sid: string) {
+    await hooks.event({ event: { type: "session.status", sessionID: sid, properties: { status: "idle" } } })
+}
+
+async function interrupted(hooks: any, sid: string) {
+    await hooks.event({ event: { type: "session.interrupted", sessionID: sid } })
+}
+
+async function userMessage(hooks: any, sid: string) {
+    await hooks["chat.message"]({ sessionID: sid }, { message: {}, parts: [] })
+}
+
+async function streamError(hooks: any, sid: string) {
+    await hooks.event({
+        event: {
+            type: "session.error",
+            sessionID: sid,
+            properties: { error: { name: "ProviderError", data: { message: "stream failed" } } },
+        },
+    })
+}
+
+// ============================================================================
+// CONTRACT TESTS — fail deterministically if someone removes the fix.
+// ============================================================================
+
+describe("Re-arm on user message: contract assertions on source", () => {
+    test("chat.message hook exists and clears both latches", () => {
+        const hookStart = SOURCE.indexOf('"chat.message"')
+        expect(hookStart).toBeGreaterThan(-1)
+        const hookEnd = SOURCE.indexOf('"tool.execute.before"', hookStart)
+        expect(hookEnd).toBeGreaterThan(hookStart)
+        const body = SOURCE.slice(hookStart, hookEnd)
+        expect(body).toMatch(/w\.userCancelled\s*=\s*false/)
+        expect(body).toMatch(/w\.completionSignaled\s*=\s*false/)
+    })
+
+    test("chat.message ignores the plugin's own recovery prompts (continuing guard)", () => {
+        const hookStart = SOURCE.indexOf('"chat.message"')
+        const hookEnd = SOURCE.indexOf('"tool.execute.before"', hookStart)
+        const body = SOURCE.slice(hookStart, hookEnd)
+        expect(body).toMatch(/if\s*\(\s*w\.continuing\s*\)\s*return/)
+    })
+
+    test("issue #16 contract still holds: resetBusyFlags preserves userCancelled", () => {
+        const fnStart = SOURCE.indexOf("function resetBusyFlags")
+        expect(fnStart).toBeGreaterThan(-1)
+        const fnEnd = SOURCE.indexOf("// PRESERVE", fnStart)
+        expect(fnEnd).toBeGreaterThan(fnStart)
+        const body = SOURCE.slice(fnStart, fnEnd)
+        expect(body).not.toMatch(/w\.userCancelled\s*=\s*false/)
+        expect(body).not.toMatch(/w\.completionSignaled\s*=\s*false/)
+    })
+})
+
+// ============================================================================
+// BEHAVIORAL TESTS — drive the real plugin through ESC → new prompt → stall.
+// ============================================================================
+
+describe("Re-arm on user message: behavioral tests", () => {
+    test("ESC, then a new user prompt, then a stall → recovery fires again", async () => {
+        const { hooks, promptCalls } = await setup()
+        const sid = "ses_rearm"
+
+        // Round 1: user interrupts mid-run; recovery must stay quiet
+        await busy(hooks, sid)
+        await interrupted(hooks, sid)
+        await idle(hooks, sid)
+        await wait(350)
+        expect(promptCalls.length).toBe(0)
+
+        // Round 2: user types a new prompt (chat.message), session goes busy,
+        // then a streaming failure hits — recovery must be armed again
+        await userMessage(hooks, sid)
+        await busy(hooks, sid)
+        await streamError(hooks, sid)
+        await idle(hooks, sid)
+
+        const sent = await waitFor(() => promptCalls.length >= 1)
+        expect(sent).toBe(true)
+        expect(promptCalls[0]!.sid).toBe(sid)
+    })
+
+    test("without a new user prompt, ESC back-off still sticks (issue #16)", async () => {
+        const { hooks, promptCalls } = await setup()
+        const sid = "ses_stick"
+
+        await busy(hooks, sid)
+        await streamError(hooks, sid)
+        await interrupted(hooks, sid)
+
+        // Busy/idle cycles alone must not re-arm
+        await busy(hooks, sid)
+        await idle(hooks, sid)
+        await wait(350)
+        expect(promptCalls.length).toBe(0)
+    })
+
+    test("re-arm also lifts the task_complete latch", async () => {
+        const { hooks, promptCalls } = await setup()
+        const sid = "ses_done"
+
+        // task_complete latches completionSignaled
+        await busy(hooks, sid)
+        await hooks.tool.task_complete.execute({}, { sessionID: sid })
+        await idle(hooks, sid)
+        await wait(350)
+        expect(promptCalls.length).toBe(0)
+
+        // New user prompt starts a new round of work; a stall must recover
+        await userMessage(hooks, sid)
+        await busy(hooks, sid)
+        await streamError(hooks, sid)
+        await idle(hooks, sid)
+
+        const sent = await waitFor(() => promptCalls.length >= 1)
+        expect(sent).toBe(true)
+    })
+
+    test("chat.message without sessionID is a no-op", async () => {
+        const { hooks, promptCalls } = await setup()
+        await hooks["chat.message"]({}, { message: {}, parts: [] })
+        await wait(50)
+        expect(promptCalls.length).toBe(0)
+    })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -2261,6 +2261,25 @@ export const AutoResumePlugin: Plugin = async (ctx, options) => {
             "task_complete": taskCompleteTool,
         },
 
+        "chat.message": async (input) => {
+            const sid = input?.sessionID
+            if (!sid) return
+            const w = ensureWatch(sid)
+            w.lastActivityAt = Date.now()
+            // Recovery prompts this plugin sends via session.prompt() also land
+            // here, but only while `continuing` is latched (sendContinuePrompt
+            // holds it across the await). A message arriving with `continuing`
+            // unset is a genuine user (or external client) prompt: a new round
+            // of work, so lift the ESC back-off and the task_complete latch.
+            // Busy-state resets must still preserve both flags (issue #16).
+            if (w.continuing) return
+            if (w.userCancelled || w.completionSignaled) {
+                w.userCancelled = false
+                w.completionSignaled = false
+                await log("info", `${short(sid)} - new user message, re-arming auto-resume`)
+            }
+        },
+
         "tool.execute.before": async (input) => {
             if (!input?.sessionID) return
             const w = ensureWatch(input.sessionID)


### PR DESCRIPTION
## The bug

After a manual interrupt (ESC), `userCancelled` latches and every recovery path is gated on `!w.userCancelled` — but nothing ever clears it. `resetSessionFlags()` (the only place that sets it back to `false`) is defined but never called, and `resetBusyFlags()` deliberately preserves it per the issue #16 contract. So a single ESC permanently disables auto-resume for that session for the lifetime of the plugin process, even after the user resumes work themselves. The `completionSignaled` latch from `task_complete` has the same one-way behavior.

Observed in practice on v1.1.11: interrupt a working session once, continue it manually, and the plugin never auto-continues again until opencode is restarted.

## The fix

Add a `chat.message` hook that lifts both latches when a genuine user prompt arrives — a new user message is a new round of work, so auto-resume re-arms:

- The plugin's own recovery prompts also land in `chat.message`, but they are only ever in flight while `continuing` is latched (`sendContinuePrompt` holds it across the await), so the hook returns early when `w.continuing` is set. Recovery prompts never re-arm anything.
- Additionally, while `userCancelled` is latched the plugin cannot send prompts at all (`sendContinuePrompt` bails at entry), so a message arriving with the latch set and `continuing` unset is necessarily user-initiated.
- Busy-state resets are untouched: `resetBusyFlags` still preserves both flags, keeping the issue #16 contract (ESC survives busy/idle cycles that the plugin's own activity can cause).

## Tests

New `src/index.rearm.test.ts` (7 tests), following the house style of `index.issue16-regression.test.ts` and `index.pending-recovery.test.ts`:

- Contract assertions that the hook exists, clears both latches, has the `continuing` guard, and that `resetBusyFlags` still preserves the flags.
- Behavioral: ESC → new user prompt → stall ⇒ recovery fires again; ESC with no new user prompt ⇒ back-off still sticks; re-arm also lifts the `task_complete` latch; missing `sessionID` is a no-op.

Full suite: 501 pass, 0 fail.

README's "ESC cancel respected" section updated to document the re-arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)